### PR TITLE
Browser tests: Safari on Mac OS & iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Chrome | Firefox | Internet Explorer | Opera | Safari | Edge |
 |---|---|---|---|---|---|
 Android | Yes | Yes | N/A | Untested | N/A | N/A |
 iOS | No | N/A | N/A | Untested | Yes |N/A |
-Mac OS X | Yes | Yes | N/A | Untested |Yes |N/A |
+Mac OS X | Yes | Yes | N/A | Yes |Yes |N/A |
 Windows   | Yes | Yes | Yes (9+) | Untested | Yes | Yes |
 
 | |Internet Explorer   |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bower install css-components
 Chrome | Firefox | Internet Explorer | Opera | Safari | Edge |
 |---|---|---|---|---|---|
 Android | Yes | Yes | N/A | Untested | N/A | N/A |
-iOS | No | N/A | N/A | Untested | Yes |N/A |
+iOS | No | N/A | N/A | Yes | Yes |N/A |
 Mac OS X | Yes | Yes | N/A | Yes |Yes |N/A |
 Windows   | Yes | Yes | Yes (9+) | Untested | Yes | Yes |
 


### PR DESCRIPTION
# Browser Test: Safari (Mac and iOS)

I've tested both the demo at [felipefialho.com](https://css-components.felipefialho.com) and the local version.

**Local Version**: Works perfectly.
**Live Demo**: Dropdown hover not working on Safari for iOS.

---

## Tests done in:

MacBook Air 2017
**Mac OS**: Catalina 10.15
**Safari for Mac**: 13.0.2

iPhone 7
**iOS**: 13.1.2
